### PR TITLE
chore(gulp.minify.bower): Supress angular file sort from the minify:b…

### DIFF
--- a/gulp/tasks/minify.js
+++ b/gulp/tasks/minify.js
@@ -43,7 +43,6 @@ gulp.task('minify:bower',function(){
   return gulp.src(bowerFiles())
     .pipe(jsFilter)
     .pipe(sourcemaps.init())
-    .pipe(angularFilesort())
     .pipe(concat('vendor.js'))
     .pipe(rename(function (path) {
       path.basename += ".min";


### PR DESCRIPTION
…ower task

We removed angular file sort from the gulp minify:bower task because it wasn't needed and generated
bugs